### PR TITLE
Run format checker on 6.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,8 @@ jobs:
         name: Soundness
         uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
         with:
-            api_breakage_check_container_image: "swift:6.1-noble"
+            api_breakage_check_container_image: "swift:6.2-noble"
+            format_check_container_image: "swift:6.2-noble"
             license_header_check_project_name: "SwiftHTTPServer"
 
     unit-tests:


### PR DESCRIPTION
It's currently running on 6.0 but fails because it doesn't understand new keywords such as `consuming`.