### PR TITLE
Handle channel closure properly

### DIFF
--- a/Sources/HTTPServer/HTTPResponseConcludingAsyncWriter.swift
+++ b/Sources/HTTPServer/HTTPResponseConcludingAsyncWriter.swift
@@ -116,9 +116,7 @@ public struct HTTPResponseConcludingAsyncWriter: ConcludingAsyncWriter, ~Copyabl
         let responseBodyAsyncWriter = ResponseBodyAsyncWriter(writer: self.writer)
         let (result, finalElement) = try await body(responseBodyAsyncWriter)
         try await self.writer.write(.end(finalElement))
-        self.writerState.wrapped.withLock { state in
-            state.finishedWriting = true
-        }
+        self.writerState.wrapped.withLock { $0.finishedWriting = true }
         return result
     }
 }


### PR DESCRIPTION
Will handle errors from TODOs in a follow up. This PR only makes sure we are delivering all pending writes.