### PR TITLE
Add explicit read permissions to workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Main
 
+permissions:
+  contents: read
+
 on:
     push:
         branches: [main]

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 name: PR
 
+permissions:
+  contents: read
+
 on:
     pull_request:
         types: [opened, reopened, synchronize]

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -1,5 +1,8 @@
 name: PR label
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]


### PR DESCRIPTION
Motivation:

* More secure GitHub Actions workflows

Modifications:

Add explicit 'contents: read' permissions to workflows that did not have
explicit permissions defined. This follows GitHub Actions security best
practices by limiting the default GITHUB_TOKEN permissions.

Result:

An extra layer of security.
