### PR TITLE
Add missing `nonisolated(nonsending)`

### DIFF
--- a/Sources/HTTPServer/HTTPServerClosureRequestHandler.swift
+++ b/Sources/HTTPServer/HTTPServerClosureRequestHandler.swift
@@ -114,7 +114,7 @@ extension HTTPServerProtocol {
     /// }
     /// ```
     public func serve(
-        handler: @Sendable @escaping (
+        handler: nonisolated(nonsending) @Sendable @escaping (
             _ request: HTTPRequest,
             _ requestContext: HTTPRequestContext,
             _ requestBodyAndTrailers: consuming sending RequestReader,


### PR DESCRIPTION
The server protocol's `serve` method is missing a `nonisolated(nonsending)` in its `handler` parameter. This shouldn't be strictly necessary but we've had issues with some Swift versions where closures aren't `nonisolated(nonsending)` by default, so better to be safe.