### PR TITLE
Nest SocketAddress in NIOHTTPServer

### DIFF
--- a/Sources/HTTPServer/NIOHTTPServer+ListeningAddress.swift
+++ b/Sources/HTTPServer/NIOHTTPServer+ListeningAddress.swift
@@ -124,7 +124,8 @@ extension NIOHTTPServer {
     }
 }
 
-extension SocketAddress {
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension NIOHTTPServer.SocketAddress {
     fileprivate init(_ address: NIOCore.SocketAddress?) throws(ListeningAddressError) {
         guard let address, let port = address.port else {
             throw ListeningAddressError.addressOrPortNotAvailable

--- a/Sources/HTTPServer/SocketAddress.swift
+++ b/Sources/HTTPServer/SocketAddress.swift
@@ -11,97 +11,100 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Represents an IPv4 address.
-public struct IPv4: Hashable, Sendable {
-    /// The resolved host address.
-    public var host: String
-    /// The port to connect to.
-    public var port: Int
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+extension NIOHTTPServer {
+    /// Represents an IPv4 address.
+    public struct IPv4: Hashable, Sendable {
+        /// The resolved host address.
+        public var host: String
+        /// The port to connect to.
+        public var port: Int
 
-    /// Creates a new IPv4 address.
-    ///
-    /// - Parameters:
-    ///   - host: Resolved host address.
-    ///   - port: Port to connect to.
-    public init(host: String, port: Int) {
-        self.host = host
-        self.port = port
-    }
-}
-
-/// Represents an IPv6 address.
-public struct IPv6: Hashable, Sendable {
-    /// The resolved host address.
-    public var host: String
-    /// The port to connect to.
-    public var port: Int
-
-    /// Creates a new IPv6 address.
-    ///
-    /// - Parameters:
-    ///   - host: Resolved host address.
-    ///   - port: Port to connect to.
-    public init(host: String, port: Int) {
-        self.host = host
-        self.port = port
-    }
-}
-
-/// An address to which a socket may connect or bind to.
-public struct SocketAddress: Hashable, Sendable {
-    enum Base: Hashable, Sendable {
-        case ipv4(IPv4)
-        case ipv6(IPv6)
-    }
-
-    let base: Base
-
-    /// Creates an IPv4 socket address.
-    public static func ipv4(host: String, port: Int) -> Self {
-        Self(base: .ipv4(.init(host: host, port: port)))
-    }
-
-    /// Creates an IPv6 socket address.
-    public static func ipv6(host: String, port: Int) -> Self {
-        Self(base: .ipv6(.init(host: host, port: port)))
-    }
-
-    /// Returns the address as an IPv4 address, if possible.
-    public var ipv4: IPv4? {
-        guard case .ipv4(let address) = self.base else {
-            return nil
-        }
-
-        return address
-    }
-
-    /// Returns the address as an IPv6 address, if possible.
-    public var ipv6: IPv6? {
-        guard case .ipv6(let address) = self.base else {
-            return nil
-        }
-
-        return address
-    }
-
-    /// The ``SocketAddress``'s host.
-    public var host: String {
-        switch self.base {
-        case .ipv4(let ipv4):
-            return ipv4.host
-        case .ipv6(let ipv6):
-            return ipv6.host
+        /// Creates a new IPv4 address.
+        ///
+        /// - Parameters:
+        ///   - host: Resolved host address.
+        ///   - port: Port to connect to.
+        public init(host: String, port: Int) {
+            self.host = host
+            self.port = port
         }
     }
 
-    /// The ``SocketAddress``'s port.
-    public var port: Int {
-        switch self.base {
-        case .ipv4(let ipv4):
-            return ipv4.port
+    /// Represents an IPv6 address.
+    public struct IPv6: Hashable, Sendable {
+        /// The resolved host address.
+        public var host: String
+        /// The port to connect to.
+        public var port: Int
 
-        case .ipv6(let ipv6):
-            return ipv6.port
+        /// Creates a new IPv6 address.
+        ///
+        /// - Parameters:
+        ///   - host: Resolved host address.
+        ///   - port: Port to connect to.
+        public init(host: String, port: Int) {
+            self.host = host
+            self.port = port
+        }
+    }
+
+    /// An address to which a socket may connect or bind to.
+    public struct SocketAddress: Hashable, Sendable {
+        enum Base: Hashable, Sendable {
+            case ipv4(IPv4)
+            case ipv6(IPv6)
+        }
+
+        let base: Base
+
+        /// Creates an IPv4 socket address.
+        public static func ipv4(host: String, port: Int) -> Self {
+            Self(base: .ipv4(.init(host: host, port: port)))
+        }
+
+        /// Creates an IPv6 socket address.
+        public static func ipv6(host: String, port: Int) -> Self {
+            Self(base: .ipv6(.init(host: host, port: port)))
+        }
+
+        /// Returns the address as an IPv4 address, if possible.
+        public var ipv4: IPv4? {
+            guard case .ipv4(let address) = self.base else {
+                return nil
+            }
+
+            return address
+        }
+
+        /// Returns the address as an IPv6 address, if possible.
+        public var ipv6: IPv6? {
+            guard case .ipv6(let address) = self.base else {
+                return nil
+            }
+
+            return address
+        }
+
+        /// The ``SocketAddress``'s host.
+        public var host: String {
+            switch self.base {
+            case .ipv4(let ipv4):
+                return ipv4.host
+            case .ipv6(let ipv6):
+                return ipv6.host
+            }
+        }
+
+        /// The ``SocketAddress``'s port.
+        public var port: Int {
+            switch self.base {
+            case .ipv4(let ipv4):
+                return ipv4.port
+
+            case .ipv6(let ipv6):
+                return ipv6.port
+            }
         }
     }
 }

--- a/Tests/HTTPServerTests/Utilities/Client.swift
+++ b/Tests/HTTPServerTests/Utilities/Client.swift
@@ -39,7 +39,7 @@ func setUpClient(host: String, port: Int) async throws -> ClientChannel {
 
 @available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
 func setUpClientWithMTLS(
-    at address: HTTPServer.SocketAddress,
+    at address: NIOHTTPServer.SocketAddress,
     chain: ChainPrivateKeyPair,
     trustRoots: [Certificate],
     applicationProtocol: String,


### PR DESCRIPTION
Motivation:

The `HTTPServer` module defines a `SocketAddress` type, but this has the same name as the type in the [`NIOCore` module](https://swiftpackageindex.com/apple/swift-nio/2.92.2/documentation/niocore/socketaddress).

Due to a [compiler bug](https://github.com/swiftlang/swift/issues/43510), when a module imports both `HTTPServer` and `NIOCore`, the `HTTPServer` module's `SocketAddress` type cannot be referenced, because `HTTPServer` also contains a protocol with the same name (the `HTTPServer` protocol). In this case, using the module name as a namespace qualifier doesn't work as intended:

```swift
import HTTPServer
import NIOCore

let a: SocketAddress // error: 'SocketAddress' is ambiguous for type lookup in this context

let b: HTTPServer.SocketAddress // error: 'SocketAddress' is not a member type of protocol 'HTTPServer.HTTPServer'

let c: NIOCore.SocketAddress // compiles fine.
```

Modifications:

Nested `SocketAddress` under `NIOHTTPServer`, since that type is only used in the concrete NIO implementation.

Result:

`NIOHTTPServer.SocketAddress` can be used without running into https://github.com/swiftlang/swift/issues/43510.