### PR TITLE
Update formatting Swift version to main

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       api_breakage_check_container_image: "swift:6.2-noble"
-      format_check_container_image: "swift:6.2-noble"
+      format_check_container_image: "swiftlang/swift:nightly-main-noble"  # Needed due to https://github.com/swiftlang/swift-format/issues/1081
       license_header_check_project_name: "Swift HTTP Server"
 
   unit-tests:


### PR DESCRIPTION
This PR changes the image container for the formatting action from 6.2 to main, to get around https://github.com/swiftlang/swift-format/issues/1081