### PR TITLE
Rename trait from `SwiftConfiguration` to `Configuration`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,8 +36,8 @@ let package = Package(
         )
     ],
     traits: [
-        .trait(name: "SwiftConfiguration"),
-        .default(enabledTraits: ["SwiftConfiguration"]),
+        .trait(name: "Configuration"),
+        .default(enabledTraits: ["Configuration"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-http-api-proposal", branch: "main"),
@@ -89,7 +89,7 @@ let package = Package(
                 .product(
                     name: "Configuration",
                     package: "swift-configuration",
-                    condition: .when(traits: ["SwiftConfiguration"])
+                    condition: .when(traits: ["Configuration"])
                 ),
                 .product(name: "HTTPServer", package: "swift-http-api-proposal"),
             ],

--- a/Sources/NIOHTTPServer/NIOHTTPServer+SwiftConfiguration.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer+SwiftConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if SwiftConfiguration
+#if Configuration
 public import Configuration
 import NIOCertificateReloading
 import SwiftASN1
@@ -343,4 +343,4 @@ extension CertificateVerificationMode {
         }
     }
 }
-#endif  // SwiftConfiguration
+#endif  // Configuration

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerSwiftConfigurationTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerSwiftConfigurationTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if SwiftConfiguration
+#if Configuration
 import Configuration
 import Crypto
 import Foundation
@@ -483,4 +483,4 @@ struct NIOHTTPServerSwiftConfigurationTests {
         }
     }
 }
-#endif  // SwiftConfiguration
+#endif  // Configuration


### PR DESCRIPTION
Motivation:

PR https://github.com/apple/swift-http-api-proposal/pull/107 in `swift-http-api-proposal` renames the `"SwiftConfiguration"` trait name to `"Configuration"`, as the convention is to not use the "Swift" prefix in module/product/trait names. We should do the same in this repository.

Modifications:

Renamed the `"SwiftConfiguration"` trait to `"Configuration"`.

Result:

Trait name aligns with the standard convention.