### PR TITLE
Switch from `main` to `0.0.7` for `swiftlang` soundness workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.7
     with:
       api_breakage_check_container_image: "swift:6.2-noble"
       format_check_container_image: "swiftlang/swift:nightly-main-noble"  # Needed due to https://github.com/swiftlang/swift-format/issues/1081


### PR DESCRIPTION
Motivation:

In https://github.com/swiftlang/github-workflows/pull/236, the locations of soundness scripts were changed. As a result, all soundness CI checks currently fail.

Modifications:

Replace `@main` with `0.0.7` in the soundness CI job declaration. 

Result:

Soundness CI checks will no longer be broken.