### PR TITLE
Fix `Optional.sendingTake()` sendability issues

### DIFF
--- a/Sources/NIOHTTPServer/Disconnected.swift
+++ b/Sources/NIOHTTPServer/Disconnected.swift
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP Server open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift HTTP Server project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP Server project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.1)
+// This is a helper type to move a non-Sendable value across isolation regions.
+@usableFromInline
+struct Disconnected<Value: ~Copyable>: ~Copyable, Sendable {
+    // This is safe since we take the value as sending and take consumes it
+    // and returns it as sending.
+    private nonisolated(unsafe) var value: Value?
+
+    @usableFromInline
+    init(value: consuming sending Value) {
+        unsafe self.value = .some(value)
+    }
+
+    @usableFromInline
+    consuming func take() -> sending Value {
+        nonisolated(unsafe) let value = unsafe self.value.take()!
+        return unsafe value
+    }
+
+    @usableFromInline
+    mutating func swap(newValue: consuming sending Value) -> sending Value {
+        nonisolated(unsafe) let value = unsafe self.value.take()!
+        unsafe self.value = consume newValue
+        return unsafe value
+    }
+}
+#endif

--- a/Sources/NIOHTTPServer/HTTPRequestConcludingAsyncReader.swift
+++ b/Sources/NIOHTTPServer/HTTPRequestConcludingAsyncReader.swift
@@ -197,7 +197,7 @@ public struct HTTPRequestConcludingAsyncReader: ConcludingAsyncReader, ~Copyable
     /// The type of errors that can occur during reading operations.
     public typealias Failure = any Error
 
-    private var iterator: NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator?
+    private var iterator: Disconnected<NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator?>
 
     internal var state: ReaderState
 
@@ -208,7 +208,7 @@ public struct HTTPRequestConcludingAsyncReader: ConcludingAsyncReader, ~Copyable
         iterator: consuming sending NIOAsyncChannelInboundStream<HTTPRequestPart>.AsyncIterator,
         readerState: ReaderState
     ) {
-        self.iterator = iterator
+        self.iterator = Disconnected(value: iterator)
         self.state = readerState
     }
 
@@ -240,7 +240,7 @@ public struct HTTPRequestConcludingAsyncReader: ConcludingAsyncReader, ~Copyable
     public consuming func consumeAndConclude<Return, Failure: Error>(
         body: nonisolated(nonsending) (consuming sending RequestBodyAsyncReader) async throws(Failure) -> Return
     ) async throws(Failure) -> (Return, HTTPFields?) {
-        if let iterator = self.iterator.sendingTake() {
+        if let iterator = self.iterator.take() {
             let partsReader = RequestBodyAsyncReader(iterator: iterator, readerState: self.state)
             let result = try await body(partsReader)
             let trailers = self.state.wrapped.withLock { $0.trailers }
@@ -256,11 +256,3 @@ extension HTTPRequestConcludingAsyncReader: Sendable {}
 
 @available(*, unavailable)
 extension HTTPRequestConcludingAsyncReader.RequestBodyAsyncReader: Sendable {}
-
-extension Optional {
-    mutating func sendingTake() -> sending Self {
-        let result = consume self
-        self = nil
-        return result
-    }
-}


### PR DESCRIPTION
Swift 6.3 improved region isolation diagnostics and the `sendingTake` extension on `Optional` turned out to be broken.

This PR replaces this with a new `Disconnected` type (borrowed from https://github.com/apple/swift-async-algorithms/pull/399).