### PR TITLE
Fix request error handling

### DIFF
--- a/Sources/NIOHTTPServer/NIOHTTPServer.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer.swift
@@ -289,7 +289,7 @@ public struct NIOHTTPServer: HTTPServer {
         } catch {
             self.logger.debug("Error thrown while handling connection: \(error)")
             // TODO: We need to send a response head here potentially
-            throw error
+            try? await channel.channel.close()
         }
     }
 

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
@@ -552,7 +552,6 @@ struct NIOHTTPServerTests {
                         .connectToTestHTTP1Server(at: serverAddress)
 
                     try await secondClientChannel.executeThenClose { inbound, outbound in
-                        // Only send a request head; finish the stream immediately afterwards.
                         try await outbound.write(.head(.init(method: .post, scheme: "http", authority: "", path: "/")))
                         try await outbound.write(.body(Self.bodyData))
                         try await outbound.write(.end(nil))

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
@@ -509,13 +509,88 @@ struct NIOHTTPServerTests {
             )
         }
     }
+
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    @Test("Server can still process other connections despite one failing")
+    func testServerCanContinueDespiteFailedConnection() async throws {
+        let server = try self.makePlaintextHTTP1Server()
+
+        let elg: EventLoopGroup = .singletonMultiThreadedEventLoopGroup
+        let firstRequestErrorCaught = elg.any().makePromise(of: Void.self)
+
+        try await Self.withServer(
+            server: server,
+            serverHandler: HTTPServerClosureRequestHandler { request, context, requestReader, responseSender in
+                do {
+                    try await Self.echoResponse(
+                        readUpTo: Self.bodyData.readableBytes,
+                        reader: requestReader,
+                        sender: responseSender
+                    )
+                } catch {
+                    // Complete the promise
+                    firstRequestErrorCaught.succeed()
+
+                    // Propagate the error upwards
+                    throw error
+                }
+            },
+            body: { serverAddress in
+                try await confirmation { responseReceived in
+                    let firstClientChannel = try await ClientBootstrap(group: .singletonMultiThreadedEventLoopGroup)
+                        .connectToTestHTTP1Server(at: serverAddress)
+
+                    try await firstClientChannel.executeThenClose { inbound, outbound in
+                        // Only send a request head; finish the stream immediately afterwards.
+                        try await outbound.write(.head(.init(method: .post, scheme: "http", authority: "", path: "/")))
+                        outbound.finish()
+                    }
+
+                    try await firstRequestErrorCaught.futureResult.get()
+
+                    let secondClientChannel = try await ClientBootstrap(group: .singletonMultiThreadedEventLoopGroup)
+                        .connectToTestHTTP1Server(at: serverAddress)
+
+                    try await secondClientChannel.executeThenClose { inbound, outbound in
+                        // Only send a request head; finish the stream immediately afterwards.
+                        try await outbound.write(.head(.init(method: .post, scheme: "http", authority: "", path: "/")))
+                        try await outbound.write(.body(Self.bodyData))
+                        try await outbound.write(.end(nil))
+
+                        try await Self.validateResponse(
+                            inbound,
+                            expectedHead: [Self.responseHead(status: .ok, for: .http1_1)],
+                            expectedBody: [Self.bodyData]
+                        )
+
+                        responseReceived()
+                    }
+                }
+            }
+        )
+    }
 }
+
 extension NIOHTTPServerTests {
     static let bodyData = ByteBuffer(repeating: 5, count: 100)
     static let reqBody = HTTPRequestPart.body(Self.bodyData)
 
     static let trailer: HTTPFields = [.trailer: "test_trailer"]
     static let reqEnd = HTTPRequestPart.end(trailer)
+
+    @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+    func makePlaintextHTTP1Server() throws -> NIOHTTPServer {
+        let server = NIOHTTPServer(
+            logger: self.serverLogger,
+            configuration: try .init(
+                bindTarget: .hostAndPort(host: "127.0.0.1", port: 0),
+                supportedHTTPVersions: [.http1_1],
+                transportSecurity: .plaintext
+            )
+        )
+
+        return server
+    }
 
     @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
     func makeSecureUpgradeServer() throws -> (NIOHTTPServer, ChainPrivateKeyPair) {


### PR DESCRIPTION
Motivation:

We currently [propagate errors out of the `handleRequestChannel` method](https://github.com/swift-server/swift-http-server/blob/593b7caf20b26dbb7fd5f1676ca6b98a82f58ade/Sources/NIOHTTPServer/NIOHTTPServer.swift#L292).

For the plaintext HTTP/1.1 transport, the `handleRequestChannel` method is [called from within a `withThrowingDiscardingTaskGroup`](https://github.com/swift-server/swift-http-server/blob/593b7caf20b26dbb7fd5f1676ca6b98a82f58ade/Sources/NIOHTTPServer/NIOHTTPServer%2BHTTP1_1.swift#L33) without any error catching.

Since `withThrowingDiscardingTaskGroup` [cancels itself whenever *any* of the tasks spawned inside of it throws](https://developer.apple.com/documentation/swift/withthrowingdiscardingtaskgroup(returning:isolation:body:)#Error-Handling-and-Implicit-Cancellation), an error thrown in one connection brings the entire server down. We should fix this.

Modifications:

- Modified the behaviour of `handleRequestChannel` to close the channel when an error is caught instead of propagating the error upwards. 
- Added an associated test case.

Result:
 
An error thrown in a plaintext HTTP/1.1 connection no longer results in the parent task group being cancelled.