### PR TITLE
Add `Connection: close` header to responses temporarily

### DIFF
--- a/Sources/NIOHTTPServer/NIOHTTPServer.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer.swift
@@ -251,6 +251,14 @@ public struct NIOHTTPServer: HTTPServer {
                                 readerState: readerState
                             ),
                             responseSender: HTTPResponseSender { response in
+                                // TODO: The server will close the connection
+                                // after a response, the headers must include
+                                // `Connection: close` otherwise clients will
+                                // try to re-use the same connection and fail.
+                                // When the server can handle multiple requests
+                                // on the same connection, this can be removed.
+                                var response = response
+                                response.headerFields[.connection] = "close"
                                 try await outbound.write(.head(response))
                                 return HTTPResponseConcludingAsyncWriter(
                                     writer: outbound,


### PR DESCRIPTION
The server closes each client HTTP connection after writing out a single response. This confuses a client which expects to be able to pipeline multiple requests on the same connection.

To work around this, each response from the server will now include the `Connection: close` header informing the client that the connection will be closed after the response.

This causes issues with AsyncHTTPClient in particular, which does not expect this kind of non-compliance from servers.