### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,13 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
+      # Project is only 6.4+
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_enabled: false
-      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_3_enabled: false
+      # linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
@@ -29,7 +32,9 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
+      # Project is only 6.4+
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_enabled: false
-      linux_6_3_enabled: true
+      linux_6_3_enabled: false
+      linux_nightly_next_enabled: false  # should be disabled until next is 6.4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,22 +10,23 @@ on:
 jobs:
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.7
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
     with:
-      api_breakage_check_container_image: "swift:6.3-noble"
-      format_check_container_image: "swiftlang/swift:nightly-main-noble"  # Needed due to https://github.com/swiftlang/swift-format/issues/1081
+      api_breakage_check_container_image: "swiftlang/swift:nightly-main-noble"
+      format_check_container_image: "swiftlang/swift:nightly-main-noble"
       license_header_check_project_name: "Swift HTTP Server"
 
   unit-tests:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_enabled: false
+      # Project is only 6.4+
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_enabled: false
-      linux_6_3_enabled: true
-      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_3_enabled: false
+      # linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -33,11 +34,12 @@ jobs:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
     with:
-      linux_5_10_enabled: false
+      # Project is only 6.4+
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_enabled: false
-      linux_6_3_enabled: true
+      linux_6_3_enabled: false
+      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
 
   static-sdk:
     name: Static SDK
@@ -47,8 +49,9 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      linux_5_10_enabled: false
+      # Project is only 6.4+
       linux_6_0_enabled: false
       linux_6_1_enabled: false
       linux_6_2_enabled: false
-      linux_6_3_enabled: true
+      linux_6_3_enabled: false
+      linux_nightly_next_enabled: false  # should be disabled until next is 6.4


### PR DESCRIPTION
This PR updates CI to remove Swift 5.10, disable 6.2 and 6.3 runs and use the nightly image for API breakage checks, since the project is now 6.4+ only.