### PR TITLE
Enable Swift 6.4 CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       linux_6_2_enabled: false
       linux_6_3_enabled: false
       # linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
+      linux_nightly_next_enabled: true
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
@@ -37,4 +37,4 @@ jobs:
       linux_6_1_enabled: false
       linux_6_2_enabled: false
       linux_6_3_enabled: false
-      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
+      linux_nightly_next_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
       linux_6_2_enabled: false
       linux_6_3_enabled: false
       # linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
+      linux_nightly_next_enabled: true
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -39,7 +39,7 @@ jobs:
       linux_6_1_enabled: false
       linux_6_2_enabled: false
       linux_6_3_enabled: false
-      linux_nightly_next_enabled: false  # should be disabled until next is 6.4
+      linux_nightly_next_enabled: true
 
   static-sdk:
     name: Static SDK


### PR DESCRIPTION
Motivation:

Following from https://github.com/apple/swift-nio/pull/3619, we can now enable Swift 6.4 CI checks.

Modifications:

Updated `linux_nightly_next_enabled` to `true` in `.github/workflows/pull_request.yml` and `.github/workflows/main.yml`.

Result:

We now have CI coverage.