### PR TITLE
Use Swift 6.4 image for soundness CI checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,8 +12,8 @@ jobs:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
     with:
-      api_breakage_check_container_image: "swiftlang/swift:nightly-main-noble"
-      format_check_container_image: "swiftlang/swift:nightly-main-noble"
+      api_breakage_check_container_image: "swiftlang/swift:nightly-6.4.x-noble"
+      format_check_container_image: "swiftlang/swift:nightly-6.4.x-noble"
       license_header_check_project_name: "Swift HTTP Server"
 
   unit-tests:


### PR DESCRIPTION
Motivation:

Soundness checks use the nightly-main image. They have been failing in recent PR runs due to crashes. We should use the nightly 6.4.x image for soundness checks for now.

Modifications:

Updated the soundness check workflow to use the nightly Swift 6.4.x image.

Result:

More stable soundness CI.