### PR TITLE
Disable Swift Configuration Traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.34.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
-        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0", traits: []),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),
     ],
     targets: [


### PR DESCRIPTION
Swift Configuration's default traits pull in full Foundation because they enable the JSON configuration provider, which uses JSONSerialization. That undoes all the hard work in the library to only use FoundationEssentials as full foundation will be linked anyway. Since the server doesn't need any of the trait-hidden code, let's not include them
