### PR TITLE
Default to the task-local logger

### DIFF
--- a/Sources/NIOHTTPServer/NIOHTTPServer.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer.swift
@@ -45,7 +45,6 @@ import X509
 ///
 /// ```swift
 /// let server = NIOHTTPServer(
-///     logger: logger,
 ///     configuration: try .init(
 ///         bindTarget: .hostAndPort(host: "localhost", port: 8080),
 ///         supportedHTTPVersions: [.http1_1],
@@ -80,7 +79,7 @@ public struct NIOHTTPServer: HTTPServer {
     ///   - logger: A logger instance for recording server events and debugging information.
     ///   - configuration: The server configuration including bind target and TLS settings.
     public init(
-        logger: Logger,
+        logger: Logger = .current,
         configuration: NIOHTTPServerConfiguration,
     ) {
         self.logger = logger

--- a/Tests/NIOHTTPServerTests/HTTPServerTests.swift
+++ b/Tests/NIOHTTPServerTests/HTTPServerTests.swift
@@ -23,7 +23,6 @@ struct HTTPServerTests {
     @available(anyAppleOS 26.0, *)
     func testConsumingServe() async throws {
         let server = NIOHTTPServer(
-            logger: Logger(label: "Test"),
             configuration: try .init(
                 bindTarget: .hostAndPort(host: "127.0.0.1", port: 0),
                 supportedHTTPVersions: [.http1_1],


### PR DESCRIPTION
Default the Logger parameter to the task-local logger introduced in Swift Log 1.14.0.

## Test Plan

Use the new initializer from the integration test.
