### PR TITLE
Expose the negotiated HTTP version to request handlers

### DIFF
--- a/Sources/NIOHTTPServer/HTTPServerCapability+ConnectionCapabilities.swift
+++ b/Sources/NIOHTTPServer/HTTPServerCapability+ConnectionCapabilities.swift
@@ -31,6 +31,16 @@ extension HTTPServerCapability {
         var localAddress: NIOHTTPServer.SocketAddress? { get }
     }
 
+    /// A request-context capability exposing the negotiated application protocol.
+    ///
+    /// Servers whose request context conforms to this capability surface the
+    /// application-level HTTP version negotiated for the connection carrying
+    /// the request.
+    public protocol NegotiatedHTTPVersion: RequestContext {
+        /// The application-level HTTP version negotiated for the connection.
+        var httpVersion: NIOHTTPServer.HTTPVersion { get }
+    }
+
     /// A request-context capability exposing the validated peer certificate chain.
     ///
     /// Servers whose request context conforms to this capability surface the

--- a/Sources/NIOHTTPServer/NIOHTTPServer+ConnectionContext.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer+ConnectionContext.swift
@@ -40,6 +40,7 @@ extension NIOHTTPServer {
     ///
     /// User code accesses this state via the corresponding ``RequestContext``
     /// capabilities (``HTTPServerCapability/ConnectionInfo``,
+    /// ``HTTPServerCapability/NegotiatedHTTPVersion``,
     /// ``HTTPServerCapability/PeerCertificate``) when handling individual
     /// requests, and directly when implementing an
     /// ``NIOHTTPServerConnectionHandler``.

--- a/Sources/NIOHTTPServer/NIOHTTPServer+RequestContext.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer+RequestContext.swift
@@ -22,6 +22,7 @@ extension NIOHTTPServer {
     ///
     /// Conforms to:
     /// - ``HTTPServerCapability/ConnectionInfo`` — peer / local addresses.
+    /// - ``HTTPServerCapability/NegotiatedHTTPVersion`` — negotiated HTTP version.
     /// - ``HTTPServerCapability/PeerCertificate`` — mTLS-validated peer chain.
     ///
     /// Generic library code can constrain on these capabilities to access
@@ -57,6 +58,15 @@ extension NIOHTTPServer.RequestContext: HTTPServerCapability.ConnectionInfo {
     /// Returns `nil` under the same conditions as ``remoteAddress``.
     public var localAddress: NIOHTTPServer.SocketAddress? {
         self.connectionContext.localAddress
+    }
+}
+
+@available(anyAppleOS 26.0, *)
+extension NIOHTTPServer.RequestContext: HTTPServerCapability.NegotiatedHTTPVersion {
+    /// The application-level HTTP version negotiated for the connection carrying
+    /// this request.
+    public var httpVersion: NIOHTTPServer.HTTPVersion {
+        self.connectionContext.httpVersion
     }
 }
 

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
@@ -126,6 +126,43 @@ struct NIOHTTPServerTests {
     }
 
     @available(anyAppleOS 26.0, *)
+    #if HTTP3
+    @Test(
+        "Request context reports the negotiated HTTP version",
+        arguments: [NIOHTTPServer.HTTPVersion.plaintextHTTP1_1, .http1_1, .http2, .http3]
+    )
+    #else
+    @Test(
+        "Request context reports the negotiated HTTP version",
+        arguments: [NIOHTTPServer.HTTPVersion.plaintextHTTP1_1, .http1_1, .http2]
+    )
+    #endif
+    func testRequestContextHTTPVersion(httpVersion: NIOHTTPServer.HTTPVersion) async throws {
+        let (server, clientConfiguration) = try TestHelpers.makeServerAndClientConfiguration(
+            for: httpVersion,
+            clientLogger: self.clientLogger,
+            serverLogger: self.serverLogger
+        )
+
+        try await TestHelpers.withClientServerRequestChannel(
+            clientConfiguration: clientConfiguration,
+            server: server,
+            serverHandler: HTTPServerClosureRequestHandler { request, requestContext, reader, responseWriter in
+                #expect(requestContext.httpVersion == httpVersion)
+                try await responseWriter.sendAndFinish(.init(status: .ok))
+            }
+        ) { _, inbound, outbound in
+            try await outbound.write(.testHead(method: .get, for: httpVersion))
+            try await outbound.write(.end(nil))
+
+            var iterator = inbound.makeAsyncIterator()
+            while let part = try await iterator.next() {
+                if case .end = part { break }
+            }
+        }
+    }
+
+    @available(anyAppleOS 26.0, *)
     @Test(
         "mTLS request-response with custom verification callback returning peer certificates",
         arguments: [NIOHTTPServer.HTTPVersion.http1_1, .http2]


### PR DESCRIPTION
Resolves #113.

Adds `HTTPServerCapability.NegotiatedHTTPVersion`, following the existing `ConnectionInfo` / `PeerCertificate` pattern, and conforms `NIOHTTPServer.RequestContext` to it by forwarding to the connection context. `ConnectionContext` stays internal to the handler surface. Purely additive.

Test plan: asserted the negotiated version from the request handler in the existing HTTP/1.1 and HTTP/2 end-to-end tests.