### PR TITLE
Trait-guard imports in tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
         // TODO: Update once datagram APIs are released.
         .package(url: "https://github.com/apple/swift-nio-http3.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.37.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.34.1"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.35.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.44.0"),
         .package(url: "https://github.com/apple/swift-configuration.git", from: "1.2.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.11.0"),

--- a/Sources/NIOHTTPServer/NIOHTTPServer+AbortRequest.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer+AbortRequest.swift
@@ -78,7 +78,7 @@ extension NIOHTTPServer {
     private static func quicErrorCode(_ rawValue: UInt64?) -> QUICApplicationErrorCode {
         // The force unwrap is safe: `H3_INTERNAL_ERROR` (0x0102) is always representable as a QUIC varint.
         rawValue.flatMap(QUICApplicationErrorCode.init)
-            ?? QUICApplicationErrorCode(HTTP3ErrorCode.internalError.rawValue)!
+            ?? QUICApplicationErrorCode(HTTPTypes.HTTP3ErrorCode.internalError.rawValue)!
     }
     #endif
 }

--- a/Sources/StreamResetExample/StreamResetExample.swift
+++ b/Sources/StreamResetExample/StreamResetExample.swift
@@ -43,10 +43,10 @@ extension TunnelFailure: HTTPServerHTTP2StreamResetErrorConvertible {
 #if HTTP3
 extension TunnelFailure: HTTPServerHTTP3StreamResetErrorConvertible {
     /// `H3_CONNECT_ERROR` (RFC 9114 § 8.1), the HTTP/3 counterpart of `CONNECT_ERROR`.
-    var http3StreamResetCode: UInt64 { HTTP3ErrorCode.connectError.rawValue }
+    var http3StreamResetCode: UInt64 { HTTPTypes.HTTP3ErrorCode.connectError.rawValue }
 
     /// The server is no longer reading the request body, so ask the client to stop sending it.
-    var http3StopSendingCode: UInt64 { HTTP3ErrorCode.connectError.rawValue }
+    var http3StopSendingCode: UInt64 { HTTPTypes.HTTP3ErrorCode.connectError.rawValue }
 }
 #endif
 

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerReaderTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerReaderTests.swift
@@ -16,12 +16,15 @@ import BasicContainers
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
-import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
 import Testing
 
 @testable import NIOHTTPServer
+
+#if HTTP3
+import NIOHTTP3
+#endif
 
 @Suite
 struct NIOHTTPServerReaderTests {

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerStreamResetTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerStreamResetTests.swift
@@ -39,8 +39,8 @@ extension StreamResetTestError: HTTPServerHTTP2StreamResetErrorConvertible {
 
 #if HTTP3
 extension StreamResetTestError: HTTPServerHTTP3StreamResetErrorConvertible {
-    var http3StreamResetCode: UInt64 { HTTP3ErrorCode.connectError.rawValue }
-    var http3StopSendingCode: UInt64 { HTTP3ErrorCode.connectError.rawValue }
+    var http3StreamResetCode: UInt64 { HTTPTypes.HTTP3ErrorCode.connectError.rawValue }
+    var http3StopSendingCode: UInt64 { HTTPTypes.HTTP3ErrorCode.connectError.rawValue }
 }
 #endif
 
@@ -336,7 +336,7 @@ struct NIOHTTPServerStreamResetTests {
         )
         channel.embeddedEventLoop.run()
 
-        let expectedCode = QUICApplicationErrorCode(HTTP3ErrorCode.internalError.rawValue)
+        let expectedCode = QUICApplicationErrorCode(HTTPTypes.HTTP3ErrorCode.internalError.rawValue)
         #expect(recorder.events.compactMap { $0 as? QUICResetStreamEvent }.first?.code == expectedCode)
         #expect(recorder.events.compactMap { $0 as? QUICStopSendingEvent }.first?.code == expectedCode)
 

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerStreamResetTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerStreamResetTests.swift
@@ -195,7 +195,7 @@ struct NIOHTTPServerStreamResetTests {
     @available(anyAppleOS 26.0, *)
     private func assertHTTP2Reset(
         throwing error: any Error,
-        expectedCode: HTTP2ErrorCode,
+        expectedCode: NIOHTTP2.HTTP2ErrorCode,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
         let (server, clientConfiguration) = try TestHelpers.makeServerAndClientConfiguration(
@@ -221,7 +221,7 @@ struct NIOHTTPServerStreamResetTests {
                 ]
                 try await outbound.write(.headers(.init(headers: requestHeaders, endStream: true)))
 
-                var observedCode: HTTP2ErrorCode?
+                var observedCode: NIOHTTP2.HTTP2ErrorCode?
                 for try await payload in inbound {
                     if case .rstStream(let code) = payload {
                         observedCode = code
@@ -267,7 +267,7 @@ struct NIOHTTPServerStreamResetTests {
                 try await outbound.write(.headers(.init(headers: requestHeaders, endStream: true)))
 
                 var sawResponseHeaders = false
-                var resetCode: HTTP2ErrorCode?
+                var resetCode: NIOHTTP2.HTTP2ErrorCode?
                 for try await payload in inbound {
                     switch payload {
                     case .headers:

--- a/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
+++ b/Tests/NIOHTTPServerTests/NIOHTTPServerTests.swift
@@ -18,12 +18,10 @@ import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 import NIOHTTP2
-@_spi(HTTP3AsyncInterface) import NIOHTTP3
 import NIOHTTPTypes
 import NIOHTTPTypesHTTP1
 import NIOHTTPTypesHTTP2
 import NIOPosix
-import NIOQUIC
 import NIOSSL
 import SwiftASN1
 import Synchronization
@@ -31,6 +29,11 @@ import Testing
 import X509
 
 @testable import NIOHTTPServer
+
+#if HTTP3
+@_spi(HTTP3AsyncInterface) import NIOHTTP3
+import NIOQUIC
+#endif
 
 @Suite
 struct NIOHTTPServerTests {

--- a/Tests/NIOHTTPServerTests/Utilities/Helpers.swift
+++ b/Tests/NIOHTTPServerTests/Utilities/Helpers.swift
@@ -20,7 +20,6 @@ import NIOCore
 import NIOEmbedded
 import NIOHTTPTypes
 import NIOPosix
-import NIOQUIC
 import NIOSSL
 import Testing
 import X509


### PR DESCRIPTION
### Motivation

The test target currently doesn't build under the default traits because some test files unconditionally import modules that are only available under certain traits. We should fix this.

### Modifications

- Trait-guarded imports in test files.
- Fixed ambiguous references to `HTTP2ErrorCode` and `HTTP3ErrorCode`.

### Result

Test target can successfully build.