### PR TITLE
Setup Basic Benchmarks for HTTP3

### DIFF
--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkCertificate.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkCertificate.swift
@@ -1,0 +1,49 @@
+import Crypto
+import Foundation
+import NIOHTTPServer
+import SwiftASN1
+import X509
+
+public struct BenchmarkCertificate: Sendable {
+    let certificatePath: String
+    let privateKeyPath: String
+
+    public static func makeSelfSigned() throws -> BenchmarkCertificate {
+        let key = P384.Signing.PrivateKey()
+        let name = try DistinguishedName { OrganizationName("Benchmark") }
+        let certificate = try Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(key.publicKey),
+            notValidBefore: .now - 60,
+            notValidAfter: .now + 60,
+            issuer: name,
+            subject: name,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: try .init {
+                BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+                try ExtendedKeyUsage([.serverAuth])
+                SubjectAlternativeNames([
+                    .dnsName("127.0.0.1"),
+                    .ipAddress(ASN1OctetString(contentBytes: [127, 0, 0, 1])),
+                ])
+            },
+            issuerPrivateKey: .init(key)
+        )
+
+        let uuid = UUID().uuidString
+        let certificatePath = FileManager.default.temporaryDirectory.appendingPathComponent("benchmark-cert-\(uuid)")
+        let privateKeyPath = FileManager.default.temporaryDirectory.appendingPathComponent("benchmark-key-\(uuid)")
+
+        try Data(certificate.serializeAsPEM().pemString.utf8).write(to: certificatePath)
+        try Data(Certificate.PrivateKey(key).serializeAsPEM().pemString.utf8).write(to: privateKeyPath)
+
+        return BenchmarkCertificate(certificatePath: certificatePath.path, privateKeyPath: privateKeyPath.path)
+    }
+
+    var transportSecurity: NIOHTTPServerConfiguration.TransportSecurity {
+        .tls(
+            credentials: .x509(.pemFile(certificateChainPath: certificatePath, privateKeyPath: privateKeyPath))
+        )
+    }
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Client.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Client.swift
@@ -1,0 +1,154 @@
+import HTTP3
+import HTTPTypes
+import Logging
+import NIOCore
+import NIOEmbedded
+import NIOHTTP3
+import NIOHTTPTypes
+import NIOQUIC
+import NIOQUICHelpers
+
+private final class ForwardingDestination: @unchecked Sendable {
+    private let synchronizingEventLoop: NIOAsyncTestingEventLoop
+    private var current: NIOAsyncTestingChannel?
+
+    init(synchronizingOn eventLoop: NIOAsyncTestingEventLoop) {
+        self.synchronizingEventLoop = eventLoop
+    }
+
+    func update(to channel: NIOAsyncTestingChannel) async throws {
+        try await self.synchronizingEventLoop.executeInContext { self.current = channel }
+    }
+
+    func currentChannel() async throws -> NIOAsyncTestingChannel? {
+        try await self.synchronizingEventLoop.executeInContext { self.current }
+    }
+}
+
+public final class BenchmarkHTTP3Client {
+    static let port = 9090
+
+    private let channel: NIOAsyncTestingChannel
+    private let quicHandler: NIOLoopBound<QUICHandler>
+    private let logger: Logger
+    private let destination: ForwardingDestination
+    private let forwardTask: Task<Void, any Error>
+
+    private init(
+        channel: NIOAsyncTestingChannel,
+        quicHandler: NIOLoopBound<QUICHandler>,
+        logger: Logger,
+        destination: ForwardingDestination,
+        forwardTask: Task<Void, any Error>
+    ) {
+        self.channel = channel
+        self.quicHandler = quicHandler
+        self.logger = logger
+        self.destination = destination
+        self.forwardTask = forwardTask
+    }
+
+    public static func start(
+        eventLoop: NIOAsyncTestingEventLoop,
+        certificate: BenchmarkCertificate
+    ) async throws -> BenchmarkHTTP3Client {
+        let channel = NIOAsyncTestingChannel(loop: eventLoop)
+        try await connectTestChannel(channel, localPort: Self.port, remotePort: BenchmarkHTTP3Server.port)
+
+        let logger = Logger(label: "NIOHTTPServerBenchmarks.client")
+        let quicConfiguration = QUICConfiguration.client(
+            verificationConfiguration: .x509Certificates(trustRootsFilePath: certificate.certificatePath),
+            applicationProtocols: ["h3"]
+        )
+        let asyncVerifier = try NIOQUIC.AsyncVerifier(
+            trustRootsPath: certificate.certificatePath,
+            certificateVerification: .noHostnameVerification,
+            eventLoop: channel.eventLoop
+        )
+
+        let quicHandler = try await channel.eventLoop.submit {
+            let quicHandler = QUICHandler(
+                channel: channel,
+                quicConfiguration: quicConfiguration,
+                asyncVerifier: asyncVerifier,
+                authenticator: nil,
+                logger: logger,
+                inboundConnectionInitializer: { _, _ in fatalError() },
+                inboundStreamInitializer: { _ in fatalError() },
+                noMoreConnections: {}
+            )
+            try channel.pipeline.syncOperations.addHandler(quicHandler)
+            channel.pipeline.fireChannelActive()
+            return NIOLoopBound(quicHandler, eventLoop: channel.eventLoop)
+        }.get()
+
+        let destination = ForwardingDestination(synchronizingOn: eventLoop)
+        let forwardTask = Task {
+            while !Task.isCancelled {
+                let datagram = try await channel.waitForOutboundWrite(as: AddressedEnvelope<ByteBuffer>.self)
+                if let target = try await destination.currentChannel() {
+                    try await target.writeInbound(datagram)
+                }
+            }
+        }
+
+        return BenchmarkHTTP3Client(
+            channel: channel,
+            quicHandler: quicHandler,
+            logger: logger,
+            destination: destination,
+            forwardTask: forwardTask
+        )
+    }
+
+    public func attach(to server: BenchmarkHTTP3Server) async throws {
+        try await self.destination.update(to: server.channel)
+
+        let clientChannel = self.channel
+        let serverChannel = server.channel
+        _ = Task {
+            while !Task.isCancelled {
+                let datagram = try await serverChannel.waitForOutboundWrite(as: AddressedEnvelope<ByteBuffer>.self)
+                try await clientChannel.writeInbound(datagram)
+            }
+        }
+    }
+
+    public func openConnection() async throws -> BenchmarkHTTP3Connection {
+        let logger = self.logger
+        let remoteAddress = self.channel.remoteAddress!
+        let quicHandler = self.quicHandler
+        let (channel, _) = try await self.channel.eventLoop.flatSubmit {
+            quicHandler.value.createOutboundConnection(
+                serverName: "127.0.0.1",
+                remoteAddress: remoteAddress,
+                connectionInitializer: { connectionChannel, streamCreator in
+                    connectionChannel.eventLoop.makeCompletedFuture {
+                        let h3Handler = HTTP3ConnectionHandler.client(
+                            eventLoop: connectionChannel.eventLoop,
+                            configuration: .defaults,
+                            settings: HTTP3Settings(),
+                            streamCreator: streamCreator,
+                            logger: logger,
+                            inboundPushStreamInitializer: { _ in fatalError() }
+                        )
+                        try connectionChannel.pipeline.syncOperations.addHandler(h3Handler)
+                    }
+                },
+                inboundStreamInitializer: { streamChannel in
+                    streamChannel.parent!.pipeline.handler(
+                        type: HTTP3ConnectionHandler<NIOQUIC.QUICStreamCreator>.self
+                    )
+                    .flatMap { $0.inboundStreamReceived(streamChannel) }
+                }
+            )
+        }.get()
+
+        return BenchmarkHTTP3Connection(channel: channel)
+    }
+
+    public func shutdown() async throws {
+        self.forwardTask.cancel()
+        try await self.channel.close()
+    }
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Connection.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Connection.swift
@@ -1,0 +1,72 @@
+import HTTPTypes
+import NIOCore
+import NIOHTTP3
+import NIOHTTPTypes
+import NIOQUIC
+
+public struct BenchmarkHTTP3Connection {
+    private let channel: any Channel
+
+    init(channel: any Channel) {
+        self.channel = channel
+    }
+
+    public func close() async throws {
+        try await self.channel.close()
+    }
+
+    public func openStream() async throws -> Self.Stream {
+        let channel = self.channel
+        let stream = try await channel.eventLoop.flatSubmit {
+            channel.pipeline.handler(type: HTTP3ConnectionHandler<NIOQUIC.QUICStreamCreator>.self)
+                .flatMap { h3Handler in
+                    h3Handler.createRequestStream { parameters in
+                        let streamChannel = parameters.channel
+                        return streamChannel.eventLoop.makeCompletedFuture {
+                            try NIOAsyncChannel<HTTPResponsePart, HTTPRequestPart>(
+                                wrappingChannelSynchronously: streamChannel,
+                                configuration: .init(isOutboundHalfClosureEnabled: true)
+                            )
+                        }
+                    }
+                }
+        }.get()
+
+        return Self.Stream(stream: stream)
+    }
+
+    public func download() async throws {
+        let stream = try await self.openStream()
+        try await stream.download()
+    }
+}
+
+extension BenchmarkHTTP3Connection {
+    public struct Stream {
+        private let stream: NIOAsyncChannel<HTTPResponsePart, HTTPRequestPart>
+
+        fileprivate init(stream: NIOAsyncChannel<HTTPResponsePart, HTTPRequestPart>) {
+            self.stream = stream
+        }
+
+        public func download() async throws {
+            try await stream.executeThenClose { inbound, outbound in
+                try await outbound.write(
+                    .head(HTTPRequest(method: .get, scheme: "https", authority: "benchmark", path: "/"))
+                )
+                try await outbound.write(.end(nil))
+
+                var iterator = inbound.makeAsyncIterator()
+                while let part = try await iterator.next() {
+                    if case .end = part {
+                        break
+                    }
+                }
+            }
+        }
+
+        public func close() async throws {
+            try await stream.channel.close()
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Server.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/BenchmarkHTTP3Server.swift
@@ -1,0 +1,60 @@
+import BasicContainers
+import HTTPTypes
+import Logging
+import NIOCore
+public import NIOEmbedded
+@_spi(Benchmarks) import NIOHTTPServer
+
+let benchmarkPayloadSize = 1024
+let serverPort = 8080
+let clientPort = 9090
+
+public final class BenchmarkHTTP3Server {
+    static let port = 8080
+
+    let channel: NIOAsyncTestingChannel
+    private let serveTask: Task<Void, any Error>
+
+    private init(channel: NIOAsyncTestingChannel, serveTask: Task<Void, any Error>) {
+        self.channel = channel
+        self.serveTask = serveTask
+    }
+
+    public static func start(
+        eventLoop: NIOAsyncTestingEventLoop,
+        certificate: BenchmarkCertificate
+    ) async throws -> BenchmarkHTTP3Server {
+        let channel = NIOAsyncTestingChannel(loop: eventLoop)
+        try await connectTestChannel(channel, localPort: Self.port, remotePort: BenchmarkHTTP3Client.port)
+
+        let configuration = try NIOHTTPServerConfiguration(
+            bindTarget: .hostAndPort(host: "127.0.0.1", port: 0),
+            supportedHTTPVersions: [.http3],
+            transportSecurity: certificate.transportSecurity
+        )
+        let server = NIOHTTPServer(
+            logger: Logger(label: "NIOHTTPServerBenchmarks.server"),
+            configuration: configuration
+        )
+
+        let serveTask = Task {
+            try await server.serveHTTP3OverTestChannel(
+                channel: channel,
+                handler: HTTPServerClosureRequestHandler { request, requestContext, reader, responseSender in
+                    var discard = UniqueArray<UInt8>()
+                    _ = try await reader.collect(into: &discard)
+
+                    var body = UniqueArray<UInt8>(repeating: 0, count: benchmarkPayloadSize)
+                    try await responseSender.sendAndFinish(HTTPResponse(status: .ok), buffer: &body)
+                }
+            )
+        }
+
+        return BenchmarkHTTP3Server(channel: channel, serveTask: serveTask)
+    }
+
+    public func shutdown() async throws {
+        self.serveTask.cancel()
+        try await self.channel.close()
+    }
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/TestChannelPair.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarkSupport/TestChannelPair.swift
@@ -1,0 +1,10 @@
+import NIOCore
+import NIOEmbedded
+
+func connectTestChannel(_ channel: NIOAsyncTestingChannel, localPort: Int, remotePort: Int) async throws {
+    try await channel.testingEventLoop.executeInContext {
+        channel.localAddress = try SocketAddress(ipAddress: "127.0.0.1", port: localPort)
+        channel.remoteAddress = try SocketAddress(ipAddress: "127.0.0.1", port: remotePort)
+    }
+    try await channel.connect(to: channel.remoteAddress!)
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
@@ -13,12 +13,37 @@
 //===----------------------------------------------------------------------===//
 
 import Benchmark
-import NIOHTTPServer
+import Benchmark
+import NIOEmbedded
+import NIOHTTPServerBenchmarkSupport
+
+private func makeHTTP3BenchmarkConfiguration() -> Benchmark.Configuration {
+    .init(
+        metrics: [.mallocCountTotal, .instructions, .wallClock],
+        scalingFactor: .one,
+        maxDuration: .seconds(2),
+        maxIterations: 10_000
+    )
+}
+
+let eventLoop = NIOAsyncTestingEventLoop()
+let certificate = try! BenchmarkCertificate.makeSelfSigned()
 
 let benchmarks: @Sendable () -> Void = {
-    Benchmark("Placeholder") { benchmark in
-        for _ in benchmark.scaledIterations {
-            blackHole(1 + 1)
+    var servers = [BenchmarkHTTP3Server]()
+    Benchmark(
+        "HTTP3_serverSetup",
+        configuration: makeHTTP3BenchmarkConfiguration(),
+        closure: { benchmark in
+            for _ in benchmark.scaledIterations {
+                servers.append(try await BenchmarkHTTP3Server.start(eventLoop: eventLoop, certificate: certificate))
+            }
+        },
+        teardown: {
+            for server in servers {
+                try await server.shutdown()
+            }
+            servers.removeAll()
         }
-    }
+    )
 }

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
@@ -72,4 +72,26 @@ let benchmarks: @Sendable () -> Void = {
             try await prewarmedServer.shutdown()
         }
     )
+
+    var existingConnection: BenchmarkHTTP3Connection!
+    Benchmark(
+        "HTTP3_stream",
+        configuration: makeHTTP3BenchmarkConfiguration(),
+        closure: { benchmark in
+            for _ in benchmark.scaledIterations {
+                try await existingConnection.download()
+            }
+        },
+        setup: {
+            client = try await BenchmarkHTTP3Client.start(eventLoop: eventLoop, certificate: certificate)
+            prewarmedServer = try await BenchmarkHTTP3Server.start(eventLoop: eventLoop, certificate: certificate)
+            try await client.attach(to: prewarmedServer)
+            existingConnection = try await client.openConnection()
+        },
+        teardown: {
+            try await existingConnection.close()
+            try await client.shutdown()
+            try await prewarmedServer.shutdown()
+        }
+    )
 }

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
@@ -46,4 +46,30 @@ let benchmarks: @Sendable () -> Void = {
             servers.removeAll()
         }
     )
+
+    var client: BenchmarkHTTP3Client!
+    var prewarmedServer: BenchmarkHTTP3Server!
+    var connections = [BenchmarkHTTP3Connection]()
+    Benchmark(
+        "HTTP3_openConnection",
+        configuration: makeHTTP3BenchmarkConfiguration(),
+        closure: { benchmark in
+            for _ in benchmark.scaledIterations {
+                connections.append(try await client.openConnection())
+            }
+        },
+        setup: {
+            client = try await BenchmarkHTTP3Client.start(eventLoop: eventLoop, certificate: certificate)
+            prewarmedServer = try await BenchmarkHTTP3Server.start(eventLoop: eventLoop, certificate: certificate)
+            try await client.attach(to: prewarmedServer)
+        },
+        teardown: {
+            for connection in connections {
+                try await connection.close()
+            }
+            connections.removeAll()
+            try await client.shutdown()
+            try await prewarmedServer.shutdown()
+        }
+    )
 }

--- a/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerBenchmarks/Benchmarks.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP Server open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift HTTP Server project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP Server project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import NIOHTTPServer
+
+let benchmarks: @Sendable () -> Void = {
+    Benchmark("Placeholder") { benchmark in
+        for _ in benchmark.scaledIterations {
+            blackHole(1 + 1)
+        }
+    }
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerEndToEndBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerEndToEndBenchmarks/Benchmarks.swift
@@ -1,0 +1,39 @@
+import Benchmark
+import NIOEmbedded
+import NIOHTTPServerBenchmarkSupport
+
+private func makeHTTP3BenchmarkConfiguration() -> Benchmark.Configuration {
+    .init(
+        metrics: [.mallocCountTotal, .instructions, .wallClock],
+        scalingFactor: .one,
+        maxDuration: .seconds(2),
+        maxIterations: 10_000
+    )
+}
+
+let eventLoop = NIOAsyncTestingEventLoop()
+let certificate = try! BenchmarkCertificate.makeSelfSigned()
+
+let benchmarks: @Sendable () -> Void = {
+    var client: BenchmarkHTTP3Client!
+    Benchmark(
+        "HTTP3_serverSetup_openConnection_stream",
+        configuration: makeHTTP3BenchmarkConfiguration(),
+        closure: { benchmark in
+            for _ in benchmark.scaledIterations {
+                let server = try await BenchmarkHTTP3Server.start(eventLoop: eventLoop, certificate: certificate)
+                try await client.attach(to: server)
+                let connection = try await client.openConnection()
+                try await connection.download()
+                try await connection.close()
+                try await server.shutdown()
+            }
+        },
+        setup: {
+            client = try await BenchmarkHTTP3Client.start(eventLoop: eventLoop, certificate: certificate)
+        },
+        teardown: {
+            try await client.shutdown()
+        }
+    )
+}

--- a/Benchmarks/Benchmarks/NIOHTTPServerEndToEndBenchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/NIOHTTPServerEndToEndBenchmarks/Benchmarks.swift
@@ -16,6 +16,28 @@ let certificate = try! BenchmarkCertificate.makeSelfSigned()
 
 let benchmarks: @Sendable () -> Void = {
     var client: BenchmarkHTTP3Client!
+    var prewarmedServer: BenchmarkHTTP3Server!
+    Benchmark(
+        "HTTP3_openConnection_stream",
+        configuration: makeHTTP3BenchmarkConfiguration(),
+        closure: { benchmark in
+            for _ in benchmark.scaledIterations {
+                let connection = try await client.openConnection()
+                try await connection.download()
+                try await connection.close()
+            }
+        },
+        setup: {
+            client = try await BenchmarkHTTP3Client.start(eventLoop: eventLoop, certificate: certificate)
+            prewarmedServer = try await BenchmarkHTTP3Server.start(eventLoop: eventLoop, certificate: certificate)
+            try await client.attach(to: prewarmedServer)
+        },
+        teardown: {
+            try await client.shutdown()
+            try await prewarmedServer.shutdown()
+        }
+    )
+
     Benchmark(
         "HTTP3_serverSetup_openConnection_stream",
         configuration: makeHTTP3BenchmarkConfiguration(),

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -35,7 +35,8 @@ let package = Package(
             name: "NIOHTTPServerBenchmarks",
             dependencies: [
                 .product(name: "Benchmark", package: "benchmark"),
-                .product(name: "NIOHTTPServer", package: "swift-http-server"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                "NIOHTTPServerBenchmarkSupport",
             ],
             path: "Benchmarks/NIOHTTPServerBenchmarks",
             plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -20,7 +20,15 @@ let package = Package(
     platforms: [.macOS(.v26)],
     dependencies: [
         .package(url: "https://github.com/ordo-one/benchmark", from: "1.36.2"),
-        .package(name: "swift-http-server", path: "../"),
+        .package(name: "swift-http-server", path: "../", traits: ["HTTP3"]),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.3"),
+        .package(url: "https://github.com/apple/swift-crypto.git", exact: "5.0.0-beta.2"),
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.101.3"),
+        .package(url: "https://github.com/apple/swift-nio-quic.git", .upToNextMinor(from: "0.2.2")),
+        .package(url: "https://github.com/apple/swift-nio-quic-helpers.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-nio-http3.git", branch: "main"),
     ],
     targets: [
         .executableTarget(
@@ -31,6 +39,22 @@ let package = Package(
             ],
             path: "Benchmarks/NIOHTTPServerBenchmarks",
             plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]
-        )
+        ),
+        .target(
+            name: "NIOHTTPServerBenchmarkSupport",
+            dependencies: [
+                .product(name: "NIOHTTPServer", package: "swift-http-server"),
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "X509", package: "swift-certificates"),
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "SwiftASN1", package: "swift-asn1"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                .product(name: "NIOQUIC", package: "swift-nio-quic"),
+                .product(name: "NIOQUICHelpers", package: "swift-nio-quic-helpers"),
+                .product(name: "NIOHTTP3", package: "swift-nio-http3"),
+            ],
+            path: "Benchmarks/NIOHTTPServerBenchmarkSupport",
+        ),
     ]
 )

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -41,6 +41,16 @@ let package = Package(
             path: "Benchmarks/NIOHTTPServerBenchmarks",
             plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]
         ),
+        .executableTarget(
+            name: "NIOHTTPServerEndToEndBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "NIOEmbedded", package: "swift-nio"),
+                "NIOHTTPServerBenchmarkSupport",
+            ],
+            path: "Benchmarks/NIOHTTPServerEndToEndBenchmarks",
+            plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]
+        ),
         .target(
             name: "NIOHTTPServerBenchmarkSupport",
             dependencies: [

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:6.4
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift HTTP Server open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift HTTP Server project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift HTTP Server project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "swift-http-server-benchmarks",
+    platforms: [.macOS(.v26)],
+    dependencies: [
+        .package(url: "https://github.com/ordo-one/benchmark", from: "1.36.2"),
+        .package(name: "swift-http-server", path: "../"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "NIOHTTPServerBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "benchmark"),
+                .product(name: "NIOHTTPServer", package: "swift-http-server"),
+            ],
+            path: "Benchmarks/NIOHTTPServerBenchmarks",
+            plugins: [.plugin(name: "BenchmarkPlugin", package: "benchmark")]
+        )
+    ]
+)

--- a/Sources/NIOHTTPServer/NIOHTTPServer+HTTP3.swift
+++ b/Sources/NIOHTTPServer/NIOHTTPServer+HTTP3.swift
@@ -15,8 +15,7 @@
 #if HTTP3
 import HTTP3
 import Logging
-import NIOCore
-import NIOEmbedded
+public import NIOCore
 @_spi(HTTP3AsyncInterface) import NIOHTTP3
 import NIOHTTPTypes
 import NIOPosix
@@ -352,6 +351,40 @@ extension NIOHTTPServer {
                 backPressureStrategy: .init(self.configuration.backpressureStrategy),
                 isOutboundHalfClosureEnabled: true
             )
+        )
+    }
+
+    @_spi(Benchmarks)
+    public func serveHTTP3OverTestChannel<Handler: HTTPServerRequestHandler>(
+        channel: any Channel,
+        handler: Handler
+    ) async throws
+    where
+        Handler.RequestContext == RequestContext,
+        Handler.Reader == Reader,
+        Handler.ResponseSender == ResponseSender
+    {
+        guard let http3Configuration = self.configuration.supportedHTTPVersions.http3ConfigIfSupported,
+            let authenticationConfiguration = self.configuration.quicAuthenticationConfiguration
+        else {
+
+            preconditionFailure("serveHTTP3OverTestChannel requires HTTP/3 among configuration.supportedHTTPVersions.")
+        }
+
+        let connectionMultiplexer = try await channel.eventLoop.submit {
+            let (_, connectionMultiplexer) = try self.setupQUICChannel(
+                channel: channel,
+                http3Configuration: http3Configuration,
+                authenticationConfiguration: authenticationConfiguration,
+                authenticator: self.configuration.quicAuthenticator
+            )
+            channel.pipeline.fireChannelActive()
+            return connectionMultiplexer
+        }.get()
+
+        await self.serveHTTP3(
+            connectionMultiplexer: connectionMultiplexer,
+            connectionHandler: NIOHTTPServerDefaultConnectionHandler(handler: handler)
         )
     }
 }


### PR DESCRIPTION
### Motivation

We aim to work on improving performance of the HTTP Server. In order to do so effectively, it makes sense to have a set of benchmarks to measure how we improve over time.

### Modifications

Adds a set of Benchmarks. Some are related to specific aspects of the flow. And Some are related to the general integration e2e of the server. We will track instructions, allocations, and time. 

1. How expensive is it to setup/boot up the server itself
2. How expensive is it to open a new connection
3. How expensive is it to start a new stream on an existing connection and download 1kb

In terms of more integrations, we can combine those 3 steps as follows:
1. How expensive is it to setup a server, open a new connection, start a stream and download 1kb all together (most pessimistic scenario)
2. How expensive is it to open a new connection, new stream and download 1kb on an existing pre warmed server (realistic for short lived requests)


Notes for reviewers:
1. This is my first PR working with NIO this heavily. It is very possible that I'm doing something very wrong.
2. I wanted to avoid benchmarking while using real sockets. So I had to make one function to be exposed over SPI in order to get the server running with a test channel. If this is not desired let me know. Or if we have a better way of doing this, I would appreciate some guidance
3. I'm for now still on the fence if we should be tracking any of these benchmarks using thresholds and the CI, since HTTP Server does depend on a lot of other packages which mean that performance changes might be hard to isolate to only the code in this package. I tried my best to setup benchmarks so they mainly run the http server code, but of course improvements in QUIC, HTTP Types, etc will improve these benchmarks as well, which might make tracking using CI difficult. I don't know how possible it is, but if we could have CI only verify against regressions rather than be red over improvements elsewhere in the dependency stack, that might be a good compromise   

### Result

```
=======================
NIOHTTPServerBenchmarks
=======================

HTTP3_openConnection
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *       │        23 │        24 │        24 │        24 │        24 │        25 │        28 │      1554 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *         │      3554 │      4179 │      4191 │      4203 │      4215 │      4227 │      4252 │      1554 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) * │      1201 │      1247 │      1261 │      1275 │      1290 │      1451 │      1886 │      1554 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

HTTP3_serverSetup
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (K) *       │      5489 │      5517 │      5530 │      5542 │      5554 │      5607 │      5983 │      6783 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *         │       133 │       136 │       136 │       137 │       142 │       155 │       191 │      6783 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) * │       248 │       260 │       268 │       275 │       286 │       306 │       402 │      6783 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

HTTP3_stream
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (K) *       │      3710 │      3854 │      3881 │      3916 │      3969 │      4178 │      4947 │      7191 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *         │       888 │       900 │       903 │       903 │       905 │       959 │      1033 │      7191 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) * │       221 │       251 │       256 │       263 │       270 │       295 │       920 │      7191 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

===============================
NIOHTTPServerEndToEndBenchmarks
===============================

HTTP3_openConnection_stream
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *       │        28 │        29 │        29 │        29 │        29 │        30 │        32 │      1216 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *         │      5159 │      5315 │      5319 │      5323 │      5343 │      5363 │      5409 │      1216 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) * │      1515 │      1583 │      1604 │      1630 │      1679 │      1871 │      3642 │      1216 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

HTTP3_serverSetup_openConnection_stream
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *       │        34 │        35 │        35 │        35 │        35 │        36 │        36 │      1010 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) *         │      5507 │      5539 │      5547 │      5555 │      5571 │      5603 │      5616 │      1010 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) * │      1843 │      1928 │      1947 │      1967 │      1997 │      2171 │      2835 │      1010 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```