### PR TITLE
Handle errorCaught in HTTPKeepAliveHandler

### DIFF
--- a/Sources/NIOHTTPServer/HTTPKeepAliveHandler.swift
+++ b/Sources/NIOHTTPServer/HTTPKeepAliveHandler.swift
@@ -62,6 +62,8 @@ final class HTTPKeepAliveHandler: ChannelDuplexHandler {
         /// `closeAfterResponseEnd` is true, the head carried `Connection: close`
         /// and we close once response `.end` is written.
         case streaming
+        /// A connection error was encountered previously.
+        case previousError
     }
 
     /// `true` when the request `.end` has been received on the inbound side, or no
@@ -128,6 +130,10 @@ final class HTTPKeepAliveHandler: ChannelDuplexHandler {
             // The head is already on the wire and cannot be recalled. The response is abandoned, so the client observes
             // it as truncated — again without a fabricated `.end`.
             ()
+
+        case .previousError:
+            // A connection error was encountered previously. Drop the write.
+            return
         }
 
         context.flush()
@@ -197,7 +203,16 @@ final class HTTPKeepAliveHandler: ChannelDuplexHandler {
                 context.flush()
                 context.close(mode: .output, promise: nil)
             }
+        case .previousError:
+            // A connection error was encountered previously. Drop the write.
+            ()
         }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: any Error) {
+        self.finalResponseState = .previousError
+        context.fireErrorCaught(error)
+        context.close(promise: nil)
     }
 
     func flush(context: ChannelHandlerContext) {


### PR DESCRIPTION
### Motivation

When an inbound HTTP/1.1 connection error is encountered, `swift-nio`'s [`HTTPServerProtocolErrorHandler`](https://github.com/apple/swift-nio/blob/61a7fe1bdaae266648d0b9ceb7631bafc083b9c5/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift#L39-L51) handler automatically sends a `400 Bad Request` response and propagates the error down the pipeline.

However, `HTTPKeepAliveHandler` currently just ignores inbound errors. As a result, we can end up writing a response _after_ the 400 response has been written, and consequently trigger the `preconditionFailure` imposed by `HTTPServerProtocolErrorHandler` (see [this](https://github.com/apple/swift-nio/blame/61a7fe1bdaae266648d0b9ceb7631bafc083b9c5/Sources/NIOHTTP1/HTTPServerProtocolErrorHandler.swift#L63)).

We should close the connection upon receiving an inbound error and transition to a state that prohibits further writes.

### Modifications

Added an `errorCaught` implementation which closes the channel and transitions to the newly added `previousError` state.

### Result

HTTP/1.1 channel is closed after an inbound error.